### PR TITLE
Alow custom MPI_HOME in build.sh and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ AMEM groupID:170 pid:197780 total allocBytes:6043992064 (5764 MB)
 
 #### Key Environment Variables
 ```bash
-NCCL_ENABLE_CUMEM=1    # Required: enable NCCL CUMEM
+NCCL_CUMEM_ENABLE=1    # Required: enable NCCL CUMEM
 AMEM_ENABLE=1          # Enable NCCL memory offload/restore
 AMEM_GROUPID=xxx       # Assign distinct group IDs for training/inference processes
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -188,7 +188,7 @@ AMEM groupID:170 pid:197780 total allocBytes:6043992064 (5764 MB)
 
 **重要参数：**
 
-+ NCCL_ENABLE_CUMEM=1  #必须打开NCCL CUMEM
++ NCCL_CUMEM_ENABLE=1  #必须打开NCCL CUMEM
 + AMEM_ENABLE=1 # 激活 NCCL Mem 卸载与恢复。框架层需按需调用 API
 + AMEM_GROUPID=xxx  #为训练和推理进程组设置不同的 groupID
     - 注：当和 RL 框架集成时，以上环境变量需要传递给 Ray 或训推框架

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ build_project() {
     # build nccl-tests
     cd $THIRD_NCCL_TEST;
     make -j96 MPI=1 \
-        MPI_HOME=/opt/hpcx/ompi \
+        MPI_HOME=${MPI_HOME:-/opt/hpcx/ompi} \
         NCCL_HOME=$THIRD_NCCL/build \
         NVCC_GENCODE="-gencode arch=compute_80,code=sm_80 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100a,code=sm_100a"
     cd $AMEM_ROOT_DIR;


### PR DESCRIPTION
Thank you so much for open sourcing this plugin!
This PR is trying to fix 2 typo:
- In the `build.sh` we need to allow users to pass in their own `MPI_HOME`;
- The env var in `amem_nccl.cpp` is `NCCL_CUMEM_ENABLE`.

Thank you for your time on reviewing this PR :)